### PR TITLE
feat: sync with Fabric REST API spec 2026-06-24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,7 +491,7 @@ If any validation step fails (fmt, clippy, tests, cross-check), the script abort
   - `fabio context examples <GROUP> <CMD>` — Output shape examples for command responses
 - **Dashboard**: list (read-only, portal-created)
 - **Datamart**: list (read-only, portal-created)
-- **Paginated Report**: list/update (read-only creation via portal/SSRS)
+- **Paginated Report**: list/show/create/update/delete/get-definition/update-definition (previously only list+update)
 - **RTI (Real-Time Intelligence)**: nl-to-kql (natural language to KQL translation via POST /realTimeIntelligence/nltokql?beta=true)
 - **Lakehouse query**: Resolves SQL analytics endpoint from lakehouse properties, executes T-SQL via shared TDS utilities
 - **Rest**: Raw REST passthrough command (`fabio rest call`); supports GET/POST/PUT/PATCH/DELETE; `--body` accepts inline JSON, `@file`, `@-` (stdin); `--query-params` for URL params; `--poll` for LRO; dry-run for mutating methods; `--api powerbi` targets Power BI REST API
@@ -668,7 +668,7 @@ If any validation step fails (fmt, clippy, tests, cross-check), the script abort
 - `src/commands/context.rs`: extract (workspace graph extraction — nodes/edges/summary, three-layer relationship discovery, parallel execution, incremental building)
 - `src/commands/dashboard.rs`: list (read-only)
 - `src/commands/datamart.rs`: list (read-only)
-- `src/commands/paginated_report.rs`: list/update (read-only creation)
+- `src/commands/paginated_report.rs`: list/show/create/update/delete/get-definition/update-definition
 - `src/commands/profile.rs`: save/use/list/show/delete (named profiles with defaults)
 - `src/commands/jobs.rs`: list/get/prune (local async job ledger)
 - `src/commands/feedback.rs`: send/list (two-way I/O for CLI friction reporting)
@@ -1666,6 +1666,13 @@ fabio report get-definition --workspace $WS --id $REPORT_ID
 - **OAP inbound restriction works on Trial**: `PUT /workspaces/{ws}/networking/communicationPolicy` with inbound `defaultAction: "Deny"` succeeds on Trial capacity. However, `GET .../inbound/azureResourceInstances` returns NOT_FOUND even with inbound restriction enabled — requires actual Azure Private Endpoint infrastructure to populate.
 - **Git outbound policy GET works without outbound restriction**: `GET .../outbound/git` returns `{"defaultAction":"Deny"}` even when workspace-level outbound restriction is not enabled. Only the SET (PUT) operation requires OAP to be active.
 - **Tenant settings for networking**: `WorkspaceBlockOutboundAccess` and `WorkspaceBlockInboundAccess` must be enabled at tenant level (via admin API) as prerequisites for workspace-level networking policies. `AllowAccessOverPrivateLinks` controls private link access but does not affect the tag or basic networking functionality.
+- **CMK encryption endpoints (Preview)**: Three workspace-scoped encryption endpoints:
+  - `GET /workspaces/{ws}/encryption` — Returns `WorkspaceEncryptionDetail` with `encryptionDetail.keyIdentifier`, `encryptionDetail.encryptionStatus`, optional `previousEncryptionDetail`, and optional `workspaceEncryptionItemsDetails`.
+  - `POST /workspaces/{ws}/encryption/assign` — Body: `{"keyIdentifier": "<versionless-key-uri>"}`. Returns 200 or 202 (LRO). Assigns a customer-managed key to the workspace. Requires Admin role.
+  - `POST /workspaces/{ws}/encryption/reset` — Body: `{}`. Returns 200. Removes CMK config and reverts to Microsoft-managed keys. Requires Admin role.
+- **EncryptionStatus enum values**: `Disabled`, `Active`, `EnableInProgress`, `DisableInProgress`, `Failed`.
+- **Versionless key identifier required**: The `keyIdentifier` for `assign-encryption` must be a versionless Azure Key Vault URI (e.g., `https://myvault.vault.azure.net/keys/mykey`), NOT a versioned URI with the version GUID appended.
+- **Admin list-workspaces encryption filter**: `GET /admin/workspaces?include=encryption` adds `encryption.status` and `encryption.keyIdentifier` fields to each workspace in the response. `?encryptionStatus=<status>` filters results — only valid when `include=encryption` is also specified.
 
 ## Item API Behaviors Discovered
 - **Type filter on list**: `GET /workspaces/{ws}/items?type={ItemType}` filters server-side. Type values are PascalCase (e.g., `Lakehouse`, `Notebook`, `Warehouse`).
@@ -2083,6 +2090,7 @@ fabio report get-definition --workspace $WS --id $REPORT_ID
 - **deploy-requirements requires running environment**: Returns error if environment is in `Stopping`/`Stopped` state.
 - **list-files returns directory structure**: `{"value":[{"filePath":"dags/","sizeInBytes":null},{"filePath":"plugins/","sizeInBytes":null}]}`. Directories have null `sizeInBytes`.
 - **get-compute returns pool template details**: Includes `poolTemplateId`, `poolTemplateName`, `nodeSize`, `computeScalability.minNodeCount/maxNodeCount`, `apacheAirflowJobVersion`, `apacheAirflowJobVersionDetails.apacheAirflowVersion/pythonVersion`, `availabilityZones`, `shutdownPolicy`.
+- **update-compute endpoint**: `POST /workspaces/{ws}/apacheAirflowJobs/{id}/environment/updateCompute?beta=true` with body `{"poolTemplateId": "<uuid>"}`. LRO (202 with `Retry-After: 30`). Updates which pool template is assigned to the environment. Requires `Contributor` role.
 - **Pool templates available**: `StarterPool` (ID: `00000000-...-000000000000`, Auto Pausing) and `Starter Pool (Always On)` (ID: `...000000000001`). Both are Small size, 5 nodes, Airflow 2.10.5, Python 3.12.
 - **get-workspace-settings**: Returns `{"defaultPoolTemplateId":"00000000-..."}`.
 - **Shutdown policies**: `OneHourInactivity` (auto pausing) and `AlwaysOn`.
@@ -2173,8 +2181,13 @@ fabio report get-definition --workspace $WS --id $REPORT_ID
 - **Available commands**: list, show, create (with --warehouse-id), update, delete.
 
 ## Dashboard/Datamart/Paginated Report API Behaviors Discovered
-- **Read-only list items**: Dashboard has only `list` command. Datamart has only `list`. Paginated Report has `list` and `update`.
-- **No creation via REST API**: These item types are created through the portal or Power BI Desktop. The REST API provides read-only access.
+- **Read-only list items**: Dashboard has only `list` command. Datamart has only `list`.
+- **Paginated Report now supports full CRUD + definitions**: As of spec commit 49e5f16, the Fabric REST API exposes `create`, `show` (GET), `delete`, `getDefinition` (POST LRO), and `updateDefinition` (POST LRO) endpoints for paginated reports in addition to the existing `list` and `update` (PATCH) commands.
+- **Create is LRO**: `POST /workspaces/{ws}/paginatedReports` returns 202, requires polling. Body requires `displayName` and `definition` (with `format: "PaginatedReportDefinition"` and `parts` array).
+- **Definition format is `PaginatedReportDefinition`**: Definition parts contain the `.rdl` file(s). Each part: `{"path": "ContosoReport.rdl", "payload": "<base64>", "payloadType": "InlineBase64"}`.
+- **getDefinition is LRO**: `POST .../getDefinition` with empty body `{}`. Returns 202, requires polling.
+- **updateDefinition supports `?updateMetadata=true`**: Append to URL to propagate `.platform` metadata changes.
+- **delete returns 200**: `DELETE /workspaces/{ws}/paginatedReports/{id}` returns immediately (not LRO). Supports `?hardDelete=true` for permanent deletion.
 - **Endpoint patterns**: `/workspaces/{ws}/dashboards`, `/workspaces/{ws}/datamarts`, `/workspaces/{ws}/paginatedReports/{id}`.
 
 ## Catalog API Behaviors Discovered

--- a/src/commands/admin/mod.rs
+++ b/src/commands/admin/mod.rs
@@ -149,7 +149,16 @@ pub enum AdminCommand {
     // ── Workspaces ───────────────────────────────────────────────────────
     /// List workspaces (admin view)
     #[command(display_order = 30)]
-    ListWorkspaces,
+    ListWorkspaces {
+        /// Include additional data in the response (e.g. "encryption")
+        #[arg(long)]
+        include: Option<String>,
+
+        /// Filter workspaces by encryption status (only valid when --include=encryption is set).
+        /// Valid values: `Disabled`, `Active`, `EnableInProgress`, `DisableInProgress`, `Failed`
+        #[arg(long)]
+        encryption_status: Option<String>,
+    },
     /// Show workspace details (admin view)
     #[command(display_order = 31)]
     ShowWorkspace {
@@ -538,7 +547,18 @@ pub async fn execute(cli: &Cli, client: &FabricClient, command: &AdminCommand) -
             workloads::delete_workload_assignment(cli, client, assignment_id).await
         }
         // Workspaces
-        AdminCommand::ListWorkspaces => workspaces::list_workspaces(cli, client).await,
+        AdminCommand::ListWorkspaces {
+            include,
+            encryption_status,
+        } => {
+            workspaces::list_workspaces(
+                cli,
+                client,
+                include.as_deref(),
+                encryption_status.as_deref(),
+            )
+            .await
+        }
         AdminCommand::ShowWorkspace { workspace } => {
             workspaces::show_workspace(cli, client, workspace).await
         }

--- a/src/commands/admin/workspaces.rs
+++ b/src/commands/admin/workspaces.rs
@@ -5,10 +5,28 @@ use crate::client::FabricClient;
 use crate::errors::enrich_admin;
 use crate::output;
 
-pub(super) async fn list_workspaces(cli: &Cli, client: &FabricClient) -> Result<()> {
+pub(super) async fn list_workspaces(
+    cli: &Cli,
+    client: &FabricClient,
+    include: Option<&str>,
+    encryption_status: Option<&str>,
+) -> Result<()> {
+    let mut url = "/admin/workspaces".to_string();
+    let mut params: Vec<String> = Vec::new();
+    if let Some(inc) = include {
+        params.push(format!("include={inc}"));
+    }
+    if let Some(status) = encryption_status {
+        params.push(format!("encryptionStatus={status}"));
+    }
+    if !params.is_empty() {
+        url.push('?');
+        url.push_str(&params.join("&"));
+    }
+
     let resp = client
         .get_list(
-            "/admin/workspaces",
+            &url,
             "workspaces",
             cli.all,
             cli.continuation_token.as_deref(),

--- a/src/commands/apache_airflow_job.rs
+++ b/src/commands/apache_airflow_job.rs
@@ -221,6 +221,21 @@ pub enum ApacheAirflowJobCommand {
         #[arg(long)]
         id: String,
     },
+    /// Update the compute configuration for the Airflow job environment (pool template)
+    #[command(display_order = 26)]
+    UpdateCompute {
+        /// Workspace ID
+        #[arg(short, long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+
+        /// Apache Airflow job ID
+        #[arg(long)]
+        id: String,
+
+        /// Pool template ID to assign to this environment
+        #[arg(long)]
+        pool_template_id: String,
+    },
     // ─── Files Operations ────────────────────────────────────────────────────
     /// List files (DAGs) in the Airflow job
     #[command(display_order = 30)]
@@ -465,6 +480,11 @@ pub async fn execute(
         ApacheAirflowJobCommand::GetCompute { workspace, id } => {
             get_compute(cli, client, workspace, id).await
         }
+        ApacheAirflowJobCommand::UpdateCompute {
+            workspace,
+            id,
+            pool_template_id,
+        } => update_compute(cli, client, workspace, id, pool_template_id).await,
         // Files
         ApacheAirflowJobCommand::ListFiles { workspace, id } => {
             list_files(cli, client, workspace, id).await
@@ -948,6 +968,45 @@ async fn get_compute(cli: &Cli, client: &FabricClient, workspace: &str, id: &str
         ))
         .await?;
     output::render_object(cli, &data, "compute");
+    Ok(())
+}
+
+async fn update_compute(
+    cli: &Cli,
+    client: &FabricClient,
+    workspace: &str,
+    id: &str,
+    pool_template_id: &str,
+) -> Result<()> {
+    let body = serde_json::json!({ "poolTemplateId": pool_template_id });
+
+    if output::dry_run_guard(
+        cli,
+        "apache-airflow-job update-compute",
+        &serde_json::json!({
+            "workspace": workspace,
+            "id": id,
+            "poolTemplateId": pool_template_id
+        }),
+    ) {
+        return Ok(());
+    }
+
+    let data = client
+        .post(
+            &format!("/workspaces/{workspace}/{BASE}/{id}/environment/updateCompute?beta=true"),
+            &body,
+            true,
+        )
+        .await
+        .map_err(|e| enrich_forbidden(e, "apache-airflow-job update-compute", "Contributor"))?;
+
+    if data.is_null() || data.as_object().is_some_and(serde_json::Map::is_empty) {
+        let result = serde_json::json!({ "id": id, "status": "compute_updated", "poolTemplateId": pool_template_id });
+        output::render_object(cli, &result, "status");
+    } else {
+        output::render_object(cli, &data, "id");
+    }
     Ok(())
 }
 

--- a/src/commands/notebook.rs
+++ b/src/commands/notebook.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use clap::Subcommand;
 use serde_json::Value;
@@ -983,6 +982,8 @@ fn build_run_body(
 
 #[cfg(test)]
 mod tests {
+    use base64::Engine;
+
     use super::*;
     use serde_json::json;
 

--- a/src/commands/paginated_report.rs
+++ b/src/commands/paginated_report.rs
@@ -429,8 +429,13 @@ async fn update_definition(
                 "payloadType": "InlineBase64"
             }])
         }
-        (_, Some(c)) => serde_json::from_str::<Value>(c)
-            .map_err(|e| anyhow::anyhow!("Invalid JSON in --content: {e}"))?,
+        (_, Some(c)) => serde_json::from_str::<Value>(c).unwrap_or_else(|_| {
+            serde_json::json!([{
+                "path": "report.rdl",
+                "payload": c,
+                "payloadType": "InlineBase64"
+            }])
+        }),
         (None, None) => {
             return Err(FabioError::with_hint(
                 ErrorCode::InvalidInput,
@@ -486,10 +491,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_create_dry_run_requires_file_or_content() {
-        // Verifies the error path when neither file nor content is given
-        // (tested via the actual CLI rather than unit-testing async fn directly)
-        // This test ensures the enum derives Debug correctly.
+    fn test_list_command_derives_debug() {
+        // Verifies that PaginatedReportCommand derives Debug correctly.
         let cmd = PaginatedReportCommand::List {
             workspace: "test".to_string(),
         };

--- a/src/commands/paginated_report.rs
+++ b/src/commands/paginated_report.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use clap::Subcommand;
 use serde_json::Value;
 
@@ -16,8 +18,42 @@ pub enum PaginatedReportCommand {
         #[arg(short, long, env = "FABIO_WORKSPACE")]
         workspace: String,
     },
-    /// Update paginated report properties (name and/or description)
+    /// Show details of a paginated report
     #[command(display_order = 2)]
+    Show {
+        /// Workspace ID
+        #[arg(short, long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+
+        /// Paginated report ID
+        #[arg(long)]
+        id: String,
+    },
+    /// Create a paginated report in the specified workspace (requires an RDL definition file)
+    #[command(display_order = 3)]
+    Create {
+        /// Workspace ID
+        #[arg(short, long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+
+        /// Display name
+        #[arg(long)]
+        name: String,
+
+        /// Optional description (max 256 characters)
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Path to the .rdl definition file (base64-encoded and sent as the definition)
+        #[arg(long)]
+        file: Option<String>,
+
+        /// Inline base64-encoded RDL content
+        #[arg(long)]
+        content: Option<String>,
+    },
+    /// Update paginated report properties (name and/or description)
+    #[command(display_order = 4)]
     Update {
         /// Workspace ID
         #[arg(short, long, env = "FABIO_WORKSPACE")]
@@ -35,6 +71,59 @@ pub enum PaginatedReportCommand {
         #[arg(long)]
         description: Option<String>,
     },
+    /// Delete a paginated report
+    #[command(display_order = 5)]
+    Delete {
+        /// Workspace ID
+        #[arg(short, long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+
+        /// Paginated report ID
+        #[arg(long)]
+        id: String,
+
+        /// Permanently delete (cannot be recovered)
+        #[arg(long)]
+        hard_delete: bool,
+    },
+    /// Get the public definition of a paginated report (returns the .rdl file encoded in base64)
+    #[command(display_order = 6)]
+    GetDefinition {
+        /// Workspace ID
+        #[arg(short, long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+
+        /// Paginated report ID
+        #[arg(long)]
+        id: String,
+
+        /// Decode base64 payloads inline (adds decodedPayload field)
+        #[arg(long)]
+        decode: bool,
+    },
+    /// Update the definition of a paginated report
+    #[command(display_order = 7)]
+    UpdateDefinition {
+        /// Workspace ID
+        #[arg(short, long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+
+        /// Paginated report ID
+        #[arg(long)]
+        id: String,
+
+        /// Path to the .rdl definition file
+        #[arg(long)]
+        file: Option<String>,
+
+        /// Inline base64-encoded RDL content (JSON definition parts array)
+        #[arg(long)]
+        content: Option<String>,
+
+        /// Update item metadata from .platform file when present in the definition
+        #[arg(long)]
+        update_metadata: bool,
+    },
 }
 
 pub async fn execute(
@@ -44,6 +133,25 @@ pub async fn execute(
 ) -> Result<()> {
     match command {
         PaginatedReportCommand::List { workspace } => list(cli, client, workspace).await,
+        PaginatedReportCommand::Show { workspace, id } => show(cli, client, workspace, id).await,
+        PaginatedReportCommand::Create {
+            workspace,
+            name,
+            description,
+            file,
+            content,
+        } => {
+            create(
+                cli,
+                client,
+                workspace,
+                name,
+                description.as_deref(),
+                file.as_deref(),
+                content.as_deref(),
+            )
+            .await
+        }
         PaginatedReportCommand::Update {
             workspace,
             id,
@@ -57,6 +165,34 @@ pub async fn execute(
                 id,
                 name.as_deref(),
                 description.as_deref(),
+            )
+            .await
+        }
+        PaginatedReportCommand::Delete {
+            workspace,
+            id,
+            hard_delete,
+        } => delete(cli, client, workspace, id, *hard_delete).await,
+        PaginatedReportCommand::GetDefinition {
+            workspace,
+            id,
+            decode,
+        } => get_definition(cli, client, workspace, id, *decode).await,
+        PaginatedReportCommand::UpdateDefinition {
+            workspace,
+            id,
+            file,
+            content,
+            update_metadata,
+        } => {
+            update_definition(
+                cli,
+                client,
+                workspace,
+                id,
+                file.as_deref(),
+                content.as_deref(),
+                *update_metadata,
             )
             .await
         }
@@ -81,6 +217,94 @@ async fn list(cli: &Cli, client: &FabricClient, workspace: &str) -> Result<()> {
         "id",
         resp.continuation_token.as_deref(),
     );
+    Ok(())
+}
+
+async fn show(cli: &Cli, client: &FabricClient, workspace: &str, id: &str) -> Result<()> {
+    let data = client
+        .get(&format!("/workspaces/{workspace}/paginatedReports/{id}"))
+        .await
+        .map_err(|e| enrich_forbidden(e, "paginated-report show", "Viewer"))?;
+    output::render_object(cli, &data, "id");
+    Ok(())
+}
+
+async fn create(
+    cli: &Cli,
+    client: &FabricClient,
+    workspace: &str,
+    name: &str,
+    description: Option<&str>,
+    file: Option<&str>,
+    content: Option<&str>,
+) -> Result<()> {
+    // Build the definition parts from file or content
+    let parts = match (file, content) {
+        (Some(path), _) => {
+            let rdl_bytes = std::fs::read(path)
+                .map_err(|e| anyhow::anyhow!("Failed to read file '{path}': {e}"))?;
+            let encoded = BASE64.encode(&rdl_bytes);
+            let filename = std::path::Path::new(path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("report.rdl");
+            serde_json::json!([{
+                "path": filename,
+                "payload": encoded,
+                "payloadType": "InlineBase64"
+            }])
+        }
+        (_, Some(c)) => {
+            // Expect inline JSON parts array or raw base64
+            serde_json::from_str::<Value>(c).unwrap_or_else(|_| {
+                serde_json::json!([{
+                    "path": "report.rdl",
+                    "payload": c,
+                    "payloadType": "InlineBase64"
+                }])
+            })
+        }
+        (None, None) => {
+            return Err(FabioError::with_hint(
+                ErrorCode::InvalidInput,
+                "Either --file or --content must be provided for paginated report creation".to_string(),
+                "Example: fabio paginated-report create --workspace <WS> --name \"MyReport\" --file report.rdl".to_string(),
+            ).into());
+        }
+    };
+
+    let mut body = serde_json::json!({
+        "displayName": name,
+        "definition": {
+            "format": "PaginatedReportDefinition",
+            "parts": parts
+        }
+    });
+    if let Some(desc) = description {
+        body["description"] = Value::from(desc);
+    }
+
+    if output::dry_run_guard(
+        cli,
+        "paginated-report create",
+        &serde_json::json!({
+            "workspace": workspace,
+            "displayName": name,
+            "description": description
+        }),
+    ) {
+        return Ok(());
+    }
+
+    let data = client
+        .post(
+            &format!("/workspaces/{workspace}/paginatedReports"),
+            &body,
+            true,
+        )
+        .await
+        .map_err(|e| enrich_forbidden(e, "paginated-report create", "Contributor"))?;
+    output::render_object(cli, &data, "id");
     Ok(())
 }
 
@@ -123,4 +347,152 @@ async fn update(
         .map_err(|e| enrich_forbidden(e, "paginated-report update", "Contributor"))?;
     output::render_object(cli, &data, "id");
     Ok(())
+}
+
+async fn delete(
+    cli: &Cli,
+    client: &FabricClient,
+    workspace: &str,
+    id: &str,
+    hard_delete: bool,
+) -> Result<()> {
+    if output::dry_run_guard(
+        cli,
+        "paginated-report delete",
+        &serde_json::json!({ "workspace": workspace, "id": id, "hardDelete": hard_delete }),
+    ) {
+        return Ok(());
+    }
+
+    let url = if hard_delete {
+        format!("/workspaces/{workspace}/paginatedReports/{id}?hardDelete=true")
+    } else {
+        format!("/workspaces/{workspace}/paginatedReports/{id}")
+    };
+
+    client
+        .delete(&url)
+        .await
+        .map_err(|e| enrich_forbidden(e, "paginated-report delete", "Contributor"))?;
+
+    let obj = serde_json::json!({ "id": id, "status": "deleted" });
+    output::render_object(cli, &obj, "status");
+    Ok(())
+}
+
+async fn get_definition(
+    cli: &Cli,
+    client: &FabricClient,
+    workspace: &str,
+    id: &str,
+    decode: bool,
+) -> Result<()> {
+    let data = client
+        .post(
+            &format!("/workspaces/{workspace}/paginatedReports/{id}/getDefinition"),
+            &serde_json::json!({}),
+            true,
+        )
+        .await
+        .map_err(|e| enrich_forbidden(e, "paginated-report get-definition", "Contributor"))?;
+
+    if decode {
+        let decoded = output::decode_definition_parts(data);
+        output::render_object(cli, &decoded, "definition");
+    } else {
+        output::render_object(cli, &data, "definition");
+    }
+    Ok(())
+}
+
+async fn update_definition(
+    cli: &Cli,
+    client: &FabricClient,
+    workspace: &str,
+    id: &str,
+    file: Option<&str>,
+    content: Option<&str>,
+    update_metadata: bool,
+) -> Result<()> {
+    let parts = match (file, content) {
+        (Some(path), _) => {
+            let rdl_bytes = std::fs::read(path)
+                .map_err(|e| anyhow::anyhow!("Failed to read file '{path}': {e}"))?;
+            let encoded = BASE64.encode(&rdl_bytes);
+            let filename = std::path::Path::new(path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("report.rdl");
+            serde_json::json!([{
+                "path": filename,
+                "payload": encoded,
+                "payloadType": "InlineBase64"
+            }])
+        }
+        (_, Some(c)) => serde_json::from_str::<Value>(c)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON in --content: {e}"))?,
+        (None, None) => {
+            return Err(FabioError::with_hint(
+                ErrorCode::InvalidInput,
+                "Either --file or --content must be provided".to_string(),
+                "Example: fabio paginated-report update-definition --workspace <WS> --id <ID> --file report.rdl".to_string(),
+            ).into());
+        }
+    };
+
+    let body = serde_json::json!({
+        "definition": {
+            "format": "PaginatedReportDefinition",
+            "parts": parts
+        }
+    });
+
+    if output::dry_run_guard(
+        cli,
+        "paginated-report update-definition",
+        &serde_json::json!({
+            "workspace": workspace,
+            "id": id,
+            "updateMetadata": update_metadata
+        }),
+    ) {
+        return Ok(());
+    }
+
+    let url = if update_metadata {
+        format!(
+            "/workspaces/{workspace}/paginatedReports/{id}/updateDefinition?updateMetadata=true"
+        )
+    } else {
+        format!("/workspaces/{workspace}/paginatedReports/{id}/updateDefinition")
+    };
+
+    let data = client
+        .post(&url, &body, true)
+        .await
+        .map_err(|e| enrich_forbidden(e, "paginated-report update-definition", "Contributor"))?;
+
+    if data.is_null() || data.as_object().is_some_and(serde_json::Map::is_empty) {
+        let obj = serde_json::json!({ "id": id, "status": "definition_updated" });
+        output::render_object(cli, &obj, "status");
+    } else {
+        output::render_object(cli, &data, "id");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_dry_run_requires_file_or_content() {
+        // Verifies the error path when neither file nor content is given
+        // (tested via the actual CLI rather than unit-testing async fn directly)
+        // This test ensures the enum derives Debug correctly.
+        let cmd = PaginatedReportCommand::List {
+            workspace: "test".to_string(),
+        };
+        assert!(format!("{cmd:?}").contains("List"));
+    }
 }

--- a/src/commands/workspace/mod.rs
+++ b/src/commands/workspace/mod.rs
@@ -465,6 +465,32 @@ pub enum WorkspaceCommand {
         #[arg(short = 'w', long, env = "FABIO_WORKSPACE")]
         workspace: String,
     },
+    // ─── CMK Encryption ──────────────────────────────────────────────────────
+    /// Get workspace Customer-Managed Key (CMK) encryption settings (Preview)
+    #[command(display_order = 70)]
+    GetEncryption {
+        /// Workspace ID
+        #[arg(short = 'w', long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+    },
+    /// Assign a Customer-Managed Key (CMK) to a workspace, enabling or rotating encryption (Preview)
+    #[command(display_order = 71)]
+    AssignEncryption {
+        /// Workspace ID
+        #[arg(short = 'w', long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+
+        /// Azure Key Vault key identifier (must be a versionless key URI)
+        #[arg(long)]
+        key_identifier: String,
+    },
+    /// Reset workspace encryption by removing the CMK configuration (reverts to Microsoft-managed keys) (Preview)
+    #[command(display_order = 72)]
+    ResetEncryption {
+        /// Workspace ID
+        #[arg(short = 'w', long, env = "FABIO_WORKSPACE")]
+        workspace: String,
+    },
 }
 
 #[allow(clippy::too_many_lines)]
@@ -758,6 +784,16 @@ pub async fn execute(cli: &Cli, client: &FabricClient, command: &WorkspaceComman
         }
         WorkspaceCommand::GetDatasetStorageFormat { workspace } => {
             settings::get_dataset_storage_format(cli, client, workspace).await
+        }
+        WorkspaceCommand::GetEncryption { workspace } => {
+            settings::get_encryption(cli, client, workspace).await
+        }
+        WorkspaceCommand::AssignEncryption {
+            workspace,
+            key_identifier,
+        } => settings::assign_encryption(cli, client, workspace, key_identifier).await,
+        WorkspaceCommand::ResetEncryption { workspace } => {
+            settings::reset_encryption(cli, client, workspace).await
         }
     }
 }

--- a/src/commands/workspace/settings.rs
+++ b/src/commands/workspace/settings.rs
@@ -319,3 +319,79 @@ pub(super) async fn update_settings(
     output::render_object(cli, &data, "id");
     Ok(())
 }
+
+// ─── CMK Encryption ──────────────────────────────────────────────────────────
+
+pub(super) async fn get_encryption(
+    cli: &Cli,
+    client: &FabricClient,
+    workspace: &str,
+) -> Result<()> {
+    let data = client
+        .get(&format!("/workspaces/{workspace}/encryption"))
+        .await
+        .map_err(|e| enrich_forbidden(e, "workspace get-encryption", "Admin"))?;
+    output::render_object(cli, &data, "encryptionDetail");
+    Ok(())
+}
+
+pub(super) async fn assign_encryption(
+    cli: &Cli,
+    client: &FabricClient,
+    workspace: &str,
+    key_identifier: &str,
+) -> Result<()> {
+    let body = serde_json::json!({ "keyIdentifier": key_identifier });
+    if output::dry_run_guard(
+        cli,
+        "workspace assign-encryption",
+        &serde_json::json!({ "workspace": workspace, "keyIdentifier": key_identifier }),
+    ) {
+        return Ok(());
+    }
+    let data = client
+        .post(
+            &format!("/workspaces/{workspace}/encryption/assign"),
+            &body,
+            true,
+        )
+        .await
+        .map_err(|e| enrich_forbidden(e, "workspace assign-encryption", "Admin"))?;
+    if data.is_null() || data.as_object().is_some_and(serde_json::Map::is_empty) {
+        let result = serde_json::json!({ "workspace": workspace, "status": "assign_in_progress", "keyIdentifier": key_identifier });
+        output::render_object(cli, &result, "status");
+    } else {
+        output::render_object(cli, &data, "encryptionDetail");
+    }
+    Ok(())
+}
+
+pub(super) async fn reset_encryption(
+    cli: &Cli,
+    client: &FabricClient,
+    workspace: &str,
+) -> Result<()> {
+    let body = serde_json::json!({});
+    if output::dry_run_guard(
+        cli,
+        "workspace reset-encryption",
+        &serde_json::json!({ "workspace": workspace }),
+    ) {
+        return Ok(());
+    }
+    let data = client
+        .post(
+            &format!("/workspaces/{workspace}/encryption/reset"),
+            &body,
+            false,
+        )
+        .await
+        .map_err(|e| enrich_forbidden(e, "workspace reset-encryption", "Admin"))?;
+    if data.is_null() || data.as_object().is_some_and(serde_json::Map::is_empty) {
+        let result = serde_json::json!({ "workspace": workspace, "status": "reset_complete" });
+        output::render_object(cli, &result, "status");
+    } else {
+        output::render_object(cli, &data, "encryptionDetail");
+    }
+    Ok(())
+}

--- a/tests/e2e_admin.rs
+++ b/tests/e2e_admin.rs
@@ -2153,3 +2153,27 @@ fn admin_bulk_set_labels_no_purview() {
         "Expected label-related error, got stdout={stdout} stderr={stderr}"
     );
 }
+
+// ─── Admin list-workspaces encryption params ─────────────────────────────────
+
+#[test]
+fn admin_list_workspaces_include_encryption_help() {
+    fabio()
+        .args(["admin", "list-workspaces", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[ignore = "requires live Fabric tenant with admin role"]
+#[serial]
+fn admin_list_workspaces_with_encryption_filter() {
+    let _cfg = TestConfig::from_env();
+    let assert = fabio()
+        .args(["admin", "list-workspaces", "--include", "encryption"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(json["data"].is_array());
+}

--- a/tests/e2e_apache_airflow_job.rs
+++ b/tests/e2e_apache_airflow_job.rs
@@ -48,3 +48,37 @@ fn airflow_dry_run_create() {
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     assert_eq!(json["data"]["would_execute"], "apache-airflow-job create");
 }
+
+#[test]
+fn airflow_update_compute_dry_run() {
+    fabio()
+        .args([
+            "apache-airflow-job",
+            "update-compute",
+            "--workspace",
+            "test-ws",
+            "--id",
+            "00000000-0000-0000-0000-000000000001",
+            "--pool-template-id",
+            "00000000-0000-0000-0000-000000000002",
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn airflow_update_compute_missing_pool_template_id_fails() {
+    fabio()
+        .args([
+            "apache-airflow-job",
+            "update-compute",
+            "--workspace",
+            "test-ws",
+            "--id",
+            "00000000-0000-0000-0000-000000000001",
+            // missing --pool-template-id
+        ])
+        .assert()
+        .failure();
+}

--- a/tests/e2e_paginated_report.rs
+++ b/tests/e2e_paginated_report.rs
@@ -26,3 +26,178 @@ fn paginated_report_list_returns_array() {
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     assert!(json["data"].is_array());
 }
+
+#[test]
+fn paginated_report_show_requires_id() {
+    fabio()
+        .args([
+            "paginated-report",
+            "show",
+            "--workspace",
+            "test-ws",
+            // missing --id
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn paginated_report_create_dry_run_no_file_fails() {
+    fabio()
+        .args([
+            "paginated-report",
+            "create",
+            "--workspace",
+            "test-ws",
+            "--name",
+            "TestReport",
+            "--dry-run",
+            // No --file or --content
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn paginated_report_create_dry_run_with_content() {
+    fabio()
+        .args([
+            "paginated-report",
+            "create",
+            "--workspace",
+            "test-ws",
+            "--name",
+            "TestReport",
+            "--content",
+            "PHJlcG9ydC8+", // base64 of "<report/>"
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn paginated_report_delete_dry_run() {
+    fabio()
+        .args([
+            "paginated-report",
+            "delete",
+            "--workspace",
+            "test-ws",
+            "--id",
+            "00000000-0000-0000-0000-000000000001",
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn paginated_report_get_definition_dry_run() {
+    // --dry-run on read commands: get-definition still requires auth but
+    // this test exercises flag parsing at minimum.
+    fabio()
+        .args([
+            "paginated-report",
+            "get-definition",
+            "--workspace",
+            "test-ws",
+            "--id",
+            "00000000-0000-0000-0000-000000000001",
+            "--help",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn paginated_report_update_definition_dry_run_no_file_fails() {
+    fabio()
+        .args([
+            "paginated-report",
+            "update-definition",
+            "--workspace",
+            "test-ws",
+            "--id",
+            "00000000-0000-0000-0000-000000000001",
+            "--dry-run",
+            // No --file or --content
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn paginated_report_update_definition_dry_run_with_content() {
+    fabio()
+        .args([
+            "paginated-report",
+            "update-definition",
+            "--workspace",
+            "test-ws",
+            "--id",
+            "00000000-0000-0000-0000-000000000001",
+            "--content",
+            r#"[{"path":"report.rdl","payload":"PHJlcG9ydC8+","payloadType":"InlineBase64"}]"#,
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+#[ignore = "requires live Fabric tenant"]
+#[serial]
+fn paginated_report_create_show_delete_lifecycle() {
+    use std::fs;
+    use std::io::Write;
+
+    let cfg = TestConfig::from_env();
+    let dir = tempfile::tempdir().unwrap();
+    let rdl_path = dir.path().join("test.rdl");
+    let mut f = fs::File::create(&rdl_path).unwrap();
+    f.write_all(b"<?xml version=\"1.0\"?><Report xmlns=\"http://schemas.microsoft.com/sqlserver/reporting/2008/01/reportdefinition\" />").unwrap();
+
+    let assert = fabio()
+        .args([
+            "paginated-report",
+            "create",
+            "--workspace",
+            &cfg.source_workspace,
+            "--name",
+            "fabio-e2e-paginated",
+            "--file",
+            rdl_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let id = json["data"]["id"].as_str().unwrap().to_string();
+
+    // Show
+    fabio()
+        .args([
+            "paginated-report",
+            "show",
+            "--workspace",
+            &cfg.source_workspace,
+            "--id",
+            &id,
+        ])
+        .assert()
+        .success();
+
+    // Delete
+    fabio()
+        .args([
+            "paginated-report",
+            "delete",
+            "--workspace",
+            &cfg.source_workspace,
+            "--id",
+            &id,
+        ])
+        .assert()
+        .success();
+}

--- a/tests/e2e_paginated_report.rs
+++ b/tests/e2e_paginated_report.rs
@@ -93,9 +93,8 @@ fn paginated_report_delete_dry_run() {
 }
 
 #[test]
-fn paginated_report_get_definition_dry_run() {
-    // --dry-run on read commands: get-definition still requires auth but
-    // this test exercises flag parsing at minimum.
+fn paginated_report_get_definition_help() {
+    // Exercises flag/help parsing for get-definition.
     fabio()
         .args([
             "paginated-report",

--- a/tests/e2e_workspace.rs
+++ b/tests/e2e_workspace.rs
@@ -2766,3 +2766,57 @@ fn workspace_list_capacity_combined_with_roles() {
         "expected at least one Admin workspace on our capacity"
     );
 }
+
+// ─── CMK Encryption ──────────────────────────────────────────────────────────
+
+#[test]
+fn workspace_assign_encryption_dry_run() {
+    fabio()
+        .args([
+            "workspace",
+            "assign-encryption",
+            "--workspace",
+            "00000000-0000-0000-0000-000000000001",
+            "--key-identifier",
+            "https://myvault.vault.azure.net/keys/mykey",
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn workspace_assign_encryption_missing_key_fails() {
+    fabio()
+        .args([
+            "workspace",
+            "assign-encryption",
+            "--workspace",
+            "00000000-0000-0000-0000-000000000001",
+            // missing --key-identifier
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn workspace_reset_encryption_dry_run() {
+    fabio()
+        .args([
+            "workspace",
+            "reset-encryption",
+            "--workspace",
+            "00000000-0000-0000-0000-000000000001",
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn workspace_get_encryption_help() {
+    fabio()
+        .args(["workspace", "get-encryption", "--help"])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
# Sync with Fabric REST API spec commit 49e5f16

Syncs fabio with Microsoft Fabric REST API spec changes from commit [49e5f16](https://github.com/microsoft/fabric-rest-api-specs/commit/49e5f16adc9d8aa2a3ba7acb11dc64331521f614) ("Updating swagger files.").

## Changes

### 1. Paginated Report: Full CRUD + definition support

**Spec change**: `paginatedReport/swagger.json` — added `create`, `show` (GET), `delete`, `getDefinition`, and `updateDefinition` endpoints.

Previously `paginated-report` was read-only (list + update only). The API now exposes a full lifecycle.

**New subcommands added to `paginated-report`**:
- `show` — `GET /workspaces/{ws}/paginatedReports/{id}`
- `create` — `POST /workspaces/{ws}/paginatedReports` (LRO), requires `--file` (.rdl file) or `--content` (inline base64/JSON)
- `delete` — `DELETE /workspaces/{ws}/paginatedReports/{id}`, supports `--hard-delete`
- `get-definition` — `POST .../getDefinition` (LRO), supports `--decode`
- `update-definition` — `POST .../updateDefinition` (LRO), supports `--file`, `--content`, `--update-metadata`

Definition format: `"PaginatedReportDefinition"` with `.rdl` file parts encoded as `InlineBase64`.

### 2. Apache Airflow Job: `update-compute` subcommand

**Spec change**: `apacheAirflowJob/swagger.json` — added `POST /environment/updateCompute?beta=true` endpoint.

**New subcommand**: `apache-airflow-job update-compute --workspace <WS> --id <ID> --pool-template-id <UUID>`

Assigns a pool template to the Airflow job environment. LRO operation (202 with `Retry-After: 30`). Uses `?beta=true` query parameter.

### 3. Workspace CMK Encryption: three new subcommands (Preview)

**Spec change**: `platform/swagger.json` — added three encryption management endpoints for customer-managed keys (CMK).

**New subcommands added to `workspace`**:
- `get-encryption` — `GET /workspaces/{ws}/encryption` — returns current CMK status and key identifier
- `assign-encryption` — `POST /workspaces/{ws}/encryption/assign` with `--key-identifier <uri>` — assigns/rotates the CMK (LRO)
- `reset-encryption` — `POST /workspaces/{ws}/encryption/reset` — removes CMK, reverts to Microsoft-managed keys

`EncryptionStatus` enum values: `Disabled`, `Active`, `EnableInProgress`, `DisableInProgress`, `Failed`.

### 4. Admin list-workspaces: encryption query parameters

**Spec change**: `admin/swagger.json` — added `?include=encryption` and `?encryptionStatus` query parameters to `GET /admin/workspaces`.

**Updated**: `admin list-workspaces` now accepts:
- `--include encryption` — adds `encryption.status` + `encryption.keyIdentifier` to each workspace in the response
- `--encryption-status <status>` — filters results by encryption status (only valid when `--include=encryption` is also specified)

## Files changed

| File | Change |
|------|--------|
| `src/commands/paginated_report.rs` | Expanded from 2 to 7 subcommands; added full CRUD + definition operations |
| `src/commands/apache_airflow_job.rs` | Added `UpdateCompute` variant + implementation |
| `src/commands/workspace/mod.rs` | Added `GetEncryption`, `AssignEncryption`, `ResetEncryption` variants + match arms |
| `src/commands/workspace/settings.rs` | Added `get_encryption`, `assign_encryption`, `reset_encryption` functions |
| `src/commands/admin/mod.rs` | Added `include` + `encryption_status` fields to `ListWorkspaces` variant |
| `src/commands/admin/workspaces.rs` | Updated `list_workspaces` to build URL with optional query params |
| `tests/e2e_paginated_report.rs` | Added 8 new tests (unit + offline dry-run + lifecycle) |
| `tests/e2e_apache_airflow_job.rs` | Added 2 tests for `update-compute` |
| `tests/e2e_workspace.rs` | Added 4 tests for encryption commands |
| `tests/e2e_admin.rs` | Added 2 tests for `--include encryption` |
| `AGENTS.md` | Updated Apache Airflow, Workspace, and Paginated Report behavior sections |

## Pre-commit validation

All steps passed:
- `cargo fmt -- --check` ✅
- `cargo clippy --tests -- -D warnings` ✅
- `cargo test` ✅ (780 unit tests, all integration tests passing or ignored for live tenant)
