### PR TITLE
feat: sync with Fabric REST API spec 2026-07-03

### DIFF
--- a/src/commands/context/data/agent/commands.json
+++ b/src/commands/context/data/agent/commands.json
@@ -17760,7 +17760,10 @@
           }
         },
         "mutates": true,
-        "returns": "object"
+        "returns": "object",
+        "examples": [
+          "fabio job-scheduler create-schedule --workspace $WS --id $LAKEHOUSE_ID --job-type RefreshMaterializedLakeViews --config '{\"configuration\":{\"type\":\"Cron\",\"interval\":10,\"startDateTime\":\"2025-04-28T00:00:00\",\"endDateTime\":\"2025-04-30T23:59:00\",\"localTimeZoneId\":\"UTC\"},\"executionData\":{\"mlvExecutionDefinitionId\":\"$MLV_EXEC_DEF_ID\"}}'"
+        ]
       },
       "update-schedule": {
         "description": "Update an existing schedule",

--- a/src/commands/job_scheduler.rs
+++ b/src/commands/job_scheduler.rs
@@ -19,6 +19,7 @@ pub const KNOWN_JOB_TYPES: &[&str] = &[
     "Pipeline",
     "TableMaintenance",
     "SparkJob",
+    "RefreshMaterializedLakeViews",
 ];
 
 #[derive(Debug, Subcommand)]


### PR DESCRIPTION
## Fabric REST API spec sync — b4d3581 "Updating swagger files"

### Investigation summary

I performed a full inventory of the spec diff (`/tmp/spec-changes.diff`, 2079 lines across 16 files: `eventstream/`, `lakehouse/`, `paginatedReport/`, `platform/`) and cross-checked every change against the current fabio implementation.

**Finding: this spec diff was already fully implemented in a prior sync** (commit `9aad9e8 "feat: sync with latest Fabric REST API spec changes"`). Every substantive change in the diff maps to functionality fabio already ships via its generic JSON-passthrough command design:

| Spec change | fabio coverage |
|---|---|
| Eventstream `FabricAnomalyDetectionEvents` source type + properties (`workspaceId`, `itemId`, `configurationId`, `includedEventTypes`, `filters`) | Already listed in `eventstream list-components`; source `properties` are accepted as a raw `--properties` JSON blob (no per-type Rust structs to update) — already documented in `.agents/API-BEHAVIORS-DISCOVERED.md` (EventStream section) |
| CDC source additions: `snapshotMode`, `excludedColumns`, `databaseApplicationIntent`, `snapshotSelectStatementOverrides`, `heartbeatActionQuery`, `SnapshotLockingMode.None`, `BaseSQLServerCDCSourceProperties` | Generic passthrough — no code change needed; already documented |
| Kafka/MQTT `tlsSettings` (`TrustCACertificate`, `ClientCertificate`, `CertificateResource`/`KeyVaultCertificateResource`, `TLSRevocationMode`) | Generic passthrough — no code change needed; already documented |
| Lakehouse MLV Execution Definitions (`MaterializedLakeViewExecutionDefinition`, `CurrentLakehouseExecutionContext` All/Selected, `ExtendedLineageExecutionContext` Request/Response All/Selected, `RefreshMode`, `ExecutionContextMode`) + new CRUD endpoints (`POST/GET /mlvexecutiondefinitions`, `GET/PATCH/DELETE /mlvexecutiondefinitions/{id}`) | Fully implemented in `src/commands/lakehouse/execution_definitions.rs` (list/show/create/update/delete), generic JSON body passthrough covers all discriminated-union fields |
| Lakehouse refresh-materialized-lake-views schedule gains `executionData.mlvExecutionDefinitionId` (`RefreshMaterializedLakeViewsExecutionData`) | Supported via the generic `job-scheduler create-schedule`/`update-schedule` `--config` JSON merge (flattens `configuration` + `executionData` keys into the request body); already documented at `.agents/API-BEHAVIORS-DISCOVERED.md` line 861 |
| `paginatedReport/definitions.json` doc-link typo fix (`.md` suffix removed) | Cosmetic spec-only change, no fabio-visible behavior |
| New platform `GET /workspaces/{ws}/items/{id}/relations/{upstream,downstream}?beta=true` + `RelationsResponse`/`RelationsEdge` (`RelationType` enum incl. `HiddenInWorkspace`) | Fully implemented as `fabio item list-upstream-relations`/`list-downstream-relations`, rendered via `render_object` (graph fragment, not paginated list); already documented under "Item relations (beta)" in AGENTS.md |

### Gaps found and fixed in this session

Two small completeness gaps were identified and closed:

1. **`KNOWN_JOB_TYPES` constant** (`src/commands/job_scheduler.rs`) was missing `"RefreshMaterializedLakeViews"` even though the job type is fully supported end-to-end and already documented in `.agents/API-BEHAVIORS-DISCOVERED.md`. Added it to the list for agent/documentation completeness.
2. **`commands.json` example** for `job-scheduler create-schedule` had no example demonstrating the MLV refresh-schedule `executionData.mlvExecutionDefinitionId` pattern. Added a practical example showing the full `--config` JSON shape (cron `configuration` + `executionData`).

### Count summary

- **0** new endpoints requiring new command implementation (all endpoints in the diff were already covered by existing generic CRUD/passthrough commands)
- **0** new request/response struct fields requiring Rust struct changes (all new fields flow through existing JSON passthrough parameters: `--properties`, `--content`/`--file`, `--config`)
- **0** new enum values requiring `clap::ValueEnum` changes (source types, relation types, TLS/CDC enums are all opaque strings passed through as JSON)
- **1** documentation/completeness fix: added `RefreshMaterializedLakeViews` to `KNOWN_JOB_TYPES`
- **1** agent-knowledge enrichment: added a `commands.json` example for `job-scheduler create-schedule` with MLV `executionData`
- **0** deprecations (no removed/deprecated fields in this diff)

### Validation

- `cargo fmt -- --check` — clean
- `cargo clippy --tests -- -D warnings` — zero warnings
- `cargo test --bin fabio` — 870 passed, 0 failed, 1 ignored
- `cargo test --bin fabio generate_agent_schema -- --include-ignored` — regenerated `commands.json` (picked up my new example plus pre-existing structural drift from an unrelated `--concurrency` flag and em-dash Unicode normalization, both harmless)
- `cargo test --bin fabio agent_schema_covers` — drift detection passes

### Nothing was blocked

All spec changes in this diff were either already implemented or required no code change due to fabio's generic JSON-passthrough design for source/destination properties, execution-definition bodies, and schedule configuration.
